### PR TITLE
Use npm ci in Docker build stages for deterministic frontend/backend installs

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,8 @@
+.gcloudignore
+.git
+.gitignore
+
+#!include:.gitignore
+
+!package-lock.json
+!backend/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:20-alpine AS builder
 # Set working directory
 WORKDIR /app/frontend
 
-COPY package.json .pnp.cjs .pnp.loader.mjs ./
-RUN npm install -f
+COPY package.json package-lock.json .pnp.cjs .pnp.loader.mjs ./
+RUN npm ci
 COPY . .
 RUN VITE_API_URL=__VITE_API_URL__ \
     VITE_API_VERSION=__VITE_API_VERSION__ \
@@ -23,8 +23,8 @@ FROM node:20-alpine AS backend
 WORKDIR /app
 
 # Copy backend files
-COPY backend/package.json ./
-RUN npm install
+COPY backend/package.json backend/package-lock.json ./
+RUN npm ci
 
 COPY backend/ ./
 


### PR DESCRIPTION
# Summary
This PR updates the Docker build to use npm ci instead of npm install in both frontend and backend stages.

# Changes
- Updated `.gcloudignore` so `package-lock.json` files are included in Cloud Build context

## Frontend
- Copy package-lock.json alongside package.json
- Replace `npm install -f` with `npm ci`
## Backend:
- Copy backend/package-lock.json alongside backend/package.json
- Replace `npm install` with `npm ci`



# Why
- Ensures deterministic installs in CI/image builds
- Reduces risk of drift from lockfile state
- Fails fast if package.json and lockfile are out of sync
- Aligns with standard CI/container best practices

# Impact
No functional runtime changes expected
Build behavior is now strict about lockfile consistency, which is intentional